### PR TITLE
add adminPass attribute to createServer of openstack

### DIFF
--- a/lib/pkgcloud/openstack/compute/client/servers.js
+++ b/lib/pkgcloud/openstack/compute/client/servers.js
@@ -124,6 +124,7 @@ exports.getServers = function getServers(options, callback) {
  * @param {Object}          [details.keyname]     optional keyname configuration
  * @param {Object}          [details.personality] optional personality configuration
  * @param {Object}          [details.metadata]    optional metadata configuration
+ * @param {Object}          [details.adminPass]   optional password configuration
  * @param callback
  * @returns {request|*}
  */
@@ -167,6 +168,10 @@ exports.createServer = function createServer(details, callback) {
 
   if (details.keyname) {
     createOptions.body.server.key_name = details.keyname;
+  }
+
+  if (details.adminPass) {
+    createOptions.body.server.adminPass = details.adminPass;
   }
 
   if (details.securityGroups) {


### PR DESCRIPTION
According to OpenStack doc, we can specify adminPass when create server

http://developer.openstack.org/api-ref-compute-v2.1.html
