### PR TITLE
Specify a password through the optional adminPass attribute

### DIFF
--- a/lib/pkgcloud/openstack/compute/client/servers.js
+++ b/lib/pkgcloud/openstack/compute/client/servers.js
@@ -124,6 +124,7 @@ exports.getServers = function getServers(options, callback) {
  * @param {Object}          [details.keyname]     optional keyname configuration
  * @param {Object}          [details.personality] optional personality configuration
  * @param {Object}          [details.metadata]    optional metadata configuration
+ * @param {Object}          [details.adminPass]   optional password configuration
  * @param callback
  * @returns {request|*}
  */
@@ -167,6 +168,10 @@ exports.createServer = function createServer(details, callback) {
 
   if (details.keyname) {
     createOptions.body.server.key_name = details.keyname;
+  }
+
+  if (details.adminPass) {
+    createOptions.body.server.adminPass = details.adminPass;
   }
 
   if (details.securityGroups) {


### PR DESCRIPTION
I tried provisioning new Linux VM on OpenStack then using 'eikonTest12!' to login. It's work.
I also tried provisioning new Windows VM on OpenStack then using 'eikonTest12!' to login. It's work as well.
So I would like to deploy to prod.
